### PR TITLE
Ensure only header used is host and not env

### DIFF
--- a/app.js
+++ b/app.js
@@ -470,12 +470,12 @@ const ensureAuthenticated = async (req, res, next) => {
   })
 
   if(req.headers['x-tenant-auth']) {
-    log(['x-tenant-auth header found', req.headers['x-tenant-auth'], util.getIDPDomain(req.headers)])
+    log(['x-tenant-auth header found', req.headers['x-tenant-auth'], util.getIDPDomain({ host: req.headers.host })])
 
     const [ row={} ] = await util.runQuery({
       query: 'SELECT *, id AS idp_id FROM idp WHERE domain=:domain',
       vars: {
-        domain: util.getIDPDomain(req.headers),
+        domain: util.getIDPDomain({ host: req.headers.host }),
       },
       next,
     })
@@ -537,7 +537,7 @@ const ensureAuthenticated = async (req, res, next) => {
     
     log('Checking if IDP requires authentication')
     global.connection.query('SELECT * FROM `idp` WHERE domain=?',
-      [util.getIDPDomain(req.headers)],
+      [util.getIDPDomain({ host: req.headers.host })],
       function (err, rows) {
         if (err) return next(err)
         const idp = rows[0]

--- a/src/routes/admin_routes.js
+++ b/src/routes/admin_routes.js
@@ -205,7 +205,7 @@ module.exports = function (app, s3, ensureAuthenticatedAndCheckIDP, log) {
         if(
           req.tenantAuthInfo
           && (req.tenantAuthInfo || {}).action !== 'importbook'
-          && (req.tenantAuthInfo || {}).domain !== util.getIDPDomain(req.headers)
+          && (req.tenantAuthInfo || {}).domain !== util.getIDPDomain({ host: req.headers.host })
         ) {
           throw new Error(`invalid_tenant_auth`)
         }
@@ -786,7 +786,7 @@ module.exports = function (app, s3, ensureAuthenticatedAndCheckIDP, log) {
         ORDER BY s.label
       `,
       vars: {
-        domain: util.getIDPDomain(req.headers),  // they may not be logged in, and so we find this by domain and not idpId
+        domain: util.getIDPDomain({ host: req.headers.host }),  // they may not be logged in, and so we find this by domain and not idpId
       },
       next,
     })
@@ -1211,7 +1211,7 @@ module.exports = function (app, s3, ensureAuthenticatedAndCheckIDP, log) {
         ORDER BY mk.ordering
       `,
       vars: {
-        domain: util.getIDPDomain(req.headers),  // they may not be logged in, and so we find this by domain and not idpId
+        domain: util.getIDPDomain({ host: req.headers.host }),  // they may not be logged in, and so we find this by domain and not idpId
       },
       next,
     })

--- a/src/routes/api_routes.js
+++ b/src/routes/api_routes.js
@@ -26,7 +26,7 @@ module.exports = function (app, log) {
       const [ idp={} ] = await util.runQuery({
         query: `SELECT * FROM idp WHERE domain=:domain`,
         vars: {
-          domain: util.getIDPDomain(req.headers),
+          domain: util.getIDPDomain({ host: req.headers.host }),
         },
         next,
       })

--- a/src/routes/auth_routes.js
+++ b/src/routes/auth_routes.js
@@ -445,7 +445,7 @@ module.exports = function (app, passport, authFuncs, ensureAuthenticated, logIn,
         `,
         vars: {
           email: req.query.email,
-          domain: util.getIDPDomain(req.headers),
+          domain: util.getIDPDomain({ host: req.headers.host }),
         },
         next,
       })
@@ -522,7 +522,7 @@ module.exports = function (app, passport, authFuncs, ensureAuthenticated, logIn,
         global.connection.query(
           `SELECT * FROM idp WHERE domain=:domain`,
           {
-            domain: util.getIDPDomain(req.headers),
+            domain: util.getIDPDomain({ host: req.headers.host }),
           },
           async (err2, row2) => {
             if(err2) return next(err2)

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -179,7 +179,7 @@ module.exports = function (app, s3, passport, authFuncs, ensureAuthenticated, lo
         getIco(req.user.idpId);
       } else {
         global.connection.query('SELECT id FROM `idp` WHERE domain=?',
-          [util.getIDPDomain(req.headers)],
+          [util.getIDPDomain({ host: req.headers.host })],
           function (err, rows) {
             if (err) return next(err);
             

--- a/src/routes/user_routes.js
+++ b/src/routes/user_routes.js
@@ -724,7 +724,7 @@ module.exports = function (app, ensureAuthenticatedAndCheckIDP, ensureAuthentica
       const [ idp={} ] = await util.runQuery({
         query: 'SELECT * FROM idp WHERE domain=:domain',
         vars: {
-          domain: util.getIDPDomain(req.headers),
+          domain: util.getIDPDomain({ host: req.headers.host }),
         },
         next,
       })
@@ -827,7 +827,7 @@ module.exports = function (app, ensureAuthenticatedAndCheckIDP, ensureAuthentica
     const [ idp ] = await util.runQuery({
       query: 'SELECT * FROM idp WHERE domain=:domain',
       vars: {
-        domain: util.getIDPDomain(req.headers),
+        domain: util.getIDPDomain({ host: req.headers.host }),
       },
       next,
     })

--- a/src/utils/sendEmail.js
+++ b/src/utils/sendEmail.js
@@ -29,7 +29,7 @@ const sendEmail = input => {
     global.connection.query(
       `SELECT * FROM idp WHERE domain=:domain`,
       {
-        domain: req ? util.getIDPDomain(req.headers) : `books.toadreader.com`,
+        domain: req ? util.getIDPDomain({ host: req.headers.host }) : `books.toadreader.com`,
       },
       (err, rows) => {
         if(err) {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -402,7 +402,7 @@ const util = {
     if(req.headers.host.split('.')[2] === 'staging') {
       return util.getFrontEndOrigin({ req, env: 'staging' })
     } else {
-      return `${util.getProtocol({ req })}://${util.getIDPDomain(req)}`
+      return `${util.getProtocol({ req })}://${util.getIDPDomain({ host: req.headers.host })}`
     }
   },
 
@@ -1445,7 +1445,7 @@ const util = {
     const [ idpRow ] = await util.runQuery({
       query: `SELECT id, ${jwtColInIdp} FROM idp WHERE domain=:domain`,
       vars: {
-        domain: util.getIDPDomain(req.headers),
+        domain: util.getIDPDomain({ host: req.headers.host }),
       },
       next,
     })
@@ -1478,7 +1478,7 @@ const util = {
 
     global.connection.query(
       'SELECT language FROM `idp` WHERE domain=?',
-      [util.getIDPDomain(req.headers)],
+      [util.getIDPDomain({ host: req.headers.host })],
       (err, rows) => {
         if (err) return next(err)
   


### PR DESCRIPTION
The function [getIDPDomain](https://github.com/BookLane/toad-reader-server/blob/e9af6f5db75f1b2bc9fa17166393199dc3017d8f/src/utils/util.js#L486) has two parameters: `host` and `env`. It is generally called by passing all headers, assuming that only `host` will match. However if there is a header called `env` that will match, which may cause a problem.