### PR TITLE
Prefer hostname

### DIFF
--- a/app.js
+++ b/app.js
@@ -470,12 +470,12 @@ const ensureAuthenticated = async (req, res, next) => {
   })
 
   if(req.headers['x-tenant-auth']) {
-    log(['x-tenant-auth header found', req.headers['x-tenant-auth'], util.getIDPDomain(req.headers)])
+    log(['x-tenant-auth header found', req.headers['x-tenant-auth'], util.getIDPDomain({ host: req.headers.host })])
 
     const [ row={} ] = await util.runQuery({
       query: 'SELECT *, id AS idp_id FROM idp WHERE domain=:domain',
       vars: {
-        domain: util.getIDPDomain(req.headers),
+        domain: util.getIDPDomain({ host: req.headers.host }),
       },
       next,
     })
@@ -537,7 +537,7 @@ const ensureAuthenticated = async (req, res, next) => {
     
     log('Checking if IDP requires authentication')
     global.connection.query('SELECT * FROM `idp` WHERE domain=?',
-      [util.getIDPDomain(req.headers)],
+      [util.getIDPDomain({ host: req.headers.host })],
       function (err, rows) {
         if (err) return next(err)
         const idp = rows[0]

--- a/app.js
+++ b/app.js
@@ -470,12 +470,12 @@ const ensureAuthenticated = async (req, res, next) => {
   })
 
   if(req.headers['x-tenant-auth']) {
-    log(['x-tenant-auth header found', req.headers['x-tenant-auth'], util.getIDPDomain({ host: req.headers.host })])
+    log(['x-tenant-auth header found', req.headers['x-tenant-auth'], util.getIDPDomain({ host: req.hostname || req.headers.host })])
 
     const [ row={} ] = await util.runQuery({
       query: 'SELECT *, id AS idp_id FROM idp WHERE domain=:domain',
       vars: {
-        domain: util.getIDPDomain({ host: req.headers.host }),
+        domain: util.getIDPDomain({ host: req.hostname || req.headers.host }),
       },
       next,
     })
@@ -537,7 +537,7 @@ const ensureAuthenticated = async (req, res, next) => {
     
     log('Checking if IDP requires authentication')
     global.connection.query('SELECT * FROM `idp` WHERE domain=?',
-      [util.getIDPDomain({ host: req.headers.host })],
+      [util.getIDPDomain({ host: req.hostname || req.headers.host })],
       function (err, rows) {
         if (err) return next(err)
         const idp = rows[0]

--- a/src/routes/admin_routes.js
+++ b/src/routes/admin_routes.js
@@ -205,7 +205,7 @@ module.exports = function (app, s3, ensureAuthenticatedAndCheckIDP, log) {
         if(
           req.tenantAuthInfo
           && (req.tenantAuthInfo || {}).action !== 'importbook'
-          && (req.tenantAuthInfo || {}).domain !== util.getIDPDomain({ host: req.headers.host })
+          && (req.tenantAuthInfo || {}).domain !== util.getIDPDomain({ host: req.hostname || req.headers.host })
         ) {
           throw new Error(`invalid_tenant_auth`)
         }
@@ -786,7 +786,7 @@ module.exports = function (app, s3, ensureAuthenticatedAndCheckIDP, log) {
         ORDER BY s.label
       `,
       vars: {
-        domain: util.getIDPDomain({ host: req.headers.host }),  // they may not be logged in, and so we find this by domain and not idpId
+        domain: util.getIDPDomain({ host: req.hostname || req.headers.host }),  // they may not be logged in, and so we find this by domain and not idpId
       },
       next,
     })
@@ -1211,7 +1211,7 @@ module.exports = function (app, s3, ensureAuthenticatedAndCheckIDP, log) {
         ORDER BY mk.ordering
       `,
       vars: {
-        domain: util.getIDPDomain({ host: req.headers.host }),  // they may not be logged in, and so we find this by domain and not idpId
+        domain: util.getIDPDomain({ host: req.hostname || req.headers.host }),  // they may not be logged in, and so we find this by domain and not idpId
       },
       next,
     })

--- a/src/routes/admin_routes.js
+++ b/src/routes/admin_routes.js
@@ -205,7 +205,7 @@ module.exports = function (app, s3, ensureAuthenticatedAndCheckIDP, log) {
         if(
           req.tenantAuthInfo
           && (req.tenantAuthInfo || {}).action !== 'importbook'
-          && (req.tenantAuthInfo || {}).domain !== util.getIDPDomain(req.headers)
+          && (req.tenantAuthInfo || {}).domain !== util.getIDPDomain({ host: req.headers.host })
         ) {
           throw new Error(`invalid_tenant_auth`)
         }
@@ -786,7 +786,7 @@ module.exports = function (app, s3, ensureAuthenticatedAndCheckIDP, log) {
         ORDER BY s.label
       `,
       vars: {
-        domain: util.getIDPDomain(req.headers),  // they may not be logged in, and so we find this by domain and not idpId
+        domain: util.getIDPDomain({ host: req.headers.host }),  // they may not be logged in, and so we find this by domain and not idpId
       },
       next,
     })
@@ -1211,7 +1211,7 @@ module.exports = function (app, s3, ensureAuthenticatedAndCheckIDP, log) {
         ORDER BY mk.ordering
       `,
       vars: {
-        domain: util.getIDPDomain(req.headers),  // they may not be logged in, and so we find this by domain and not idpId
+        domain: util.getIDPDomain({ host: req.headers.host }),  // they may not be logged in, and so we find this by domain and not idpId
       },
       next,
     })

--- a/src/routes/api_routes.js
+++ b/src/routes/api_routes.js
@@ -26,7 +26,7 @@ module.exports = function (app, log) {
       const [ idp={} ] = await util.runQuery({
         query: `SELECT * FROM idp WHERE domain=:domain`,
         vars: {
-          domain: util.getIDPDomain(req.headers),
+          domain: util.getIDPDomain({ host: req.headers.host }),
         },
         next,
       })

--- a/src/routes/api_routes.js
+++ b/src/routes/api_routes.js
@@ -26,7 +26,7 @@ module.exports = function (app, log) {
       const [ idp={} ] = await util.runQuery({
         query: `SELECT * FROM idp WHERE domain=:domain`,
         vars: {
-          domain: util.getIDPDomain({ host: req.headers.host }),
+          domain: util.getIDPDomain({ host: req.hostname || req.headers.host }),
         },
         next,
       })

--- a/src/routes/auth_routes.js
+++ b/src/routes/auth_routes.js
@@ -445,7 +445,7 @@ module.exports = function (app, passport, authFuncs, ensureAuthenticated, logIn,
         `,
         vars: {
           email: req.query.email,
-          domain: util.getIDPDomain(req.headers),
+          domain: util.getIDPDomain({ host: req.headers.host }),
         },
         next,
       })
@@ -522,7 +522,7 @@ module.exports = function (app, passport, authFuncs, ensureAuthenticated, logIn,
         global.connection.query(
           `SELECT * FROM idp WHERE domain=:domain`,
           {
-            domain: util.getIDPDomain(req.headers),
+            domain: util.getIDPDomain({ host: req.headers.host }),
           },
           async (err2, row2) => {
             if(err2) return next(err2)

--- a/src/routes/auth_routes.js
+++ b/src/routes/auth_routes.js
@@ -445,7 +445,7 @@ module.exports = function (app, passport, authFuncs, ensureAuthenticated, logIn,
         `,
         vars: {
           email: req.query.email,
-          domain: util.getIDPDomain({ host: req.headers.host }),
+          domain: util.getIDPDomain({ host: req.hostname || req.headers.host }),
         },
         next,
       })
@@ -522,7 +522,7 @@ module.exports = function (app, passport, authFuncs, ensureAuthenticated, logIn,
         global.connection.query(
           `SELECT * FROM idp WHERE domain=:domain`,
           {
-            domain: util.getIDPDomain({ host: req.headers.host }),
+            domain: util.getIDPDomain({ host: req.hostname || req.headers.host }),
           },
           async (err2, row2) => {
             if(err2) return next(err2)

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -179,7 +179,7 @@ module.exports = function (app, s3, passport, authFuncs, ensureAuthenticated, lo
         getIco(req.user.idpId);
       } else {
         global.connection.query('SELECT id FROM `idp` WHERE domain=?',
-          [util.getIDPDomain(req.headers)],
+          [util.getIDPDomain({ host: req.headers.host })],
           function (err, rows) {
             if (err) return next(err);
             

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -179,7 +179,7 @@ module.exports = function (app, s3, passport, authFuncs, ensureAuthenticated, lo
         getIco(req.user.idpId);
       } else {
         global.connection.query('SELECT id FROM `idp` WHERE domain=?',
-          [util.getIDPDomain({ host: req.headers.host })],
+          [util.getIDPDomain({ host: req.hostname || req.headers.host })],
           function (err, rows) {
             if (err) return next(err);
             

--- a/src/routes/user_routes.js
+++ b/src/routes/user_routes.js
@@ -724,7 +724,7 @@ module.exports = function (app, ensureAuthenticatedAndCheckIDP, ensureAuthentica
       const [ idp={} ] = await util.runQuery({
         query: 'SELECT * FROM idp WHERE domain=:domain',
         vars: {
-          domain: util.getIDPDomain(req.headers),
+          domain: util.getIDPDomain({ host: req.headers.host }),
         },
         next,
       })
@@ -827,7 +827,7 @@ module.exports = function (app, ensureAuthenticatedAndCheckIDP, ensureAuthentica
     const [ idp ] = await util.runQuery({
       query: 'SELECT * FROM idp WHERE domain=:domain',
       vars: {
-        domain: util.getIDPDomain(req.headers),
+        domain: util.getIDPDomain({ host: req.headers.host }),
       },
       next,
     })

--- a/src/routes/user_routes.js
+++ b/src/routes/user_routes.js
@@ -724,7 +724,7 @@ module.exports = function (app, ensureAuthenticatedAndCheckIDP, ensureAuthentica
       const [ idp={} ] = await util.runQuery({
         query: 'SELECT * FROM idp WHERE domain=:domain',
         vars: {
-          domain: util.getIDPDomain({ host: req.headers.host }),
+          domain: util.getIDPDomain({ host: req.hostname || req.headers.host }),
         },
         next,
       })
@@ -827,7 +827,7 @@ module.exports = function (app, ensureAuthenticatedAndCheckIDP, ensureAuthentica
     const [ idp ] = await util.runQuery({
       query: 'SELECT * FROM idp WHERE domain=:domain',
       vars: {
-        domain: util.getIDPDomain({ host: req.headers.host }),
+        domain: util.getIDPDomain({ host: req.hostname || req.headers.host }),
       },
       next,
     })

--- a/src/utils/sendEmail.js
+++ b/src/utils/sendEmail.js
@@ -29,7 +29,7 @@ const sendEmail = input => {
     global.connection.query(
       `SELECT * FROM idp WHERE domain=:domain`,
       {
-        domain: req ? util.getIDPDomain({ host: req.headers.host }) : `books.toadreader.com`,
+        domain: req ? util.getIDPDomain({ host: req.hostname || req.headers.host }) : `books.toadreader.com`,
       },
       (err, rows) => {
         if(err) {

--- a/src/utils/sendEmail.js
+++ b/src/utils/sendEmail.js
@@ -29,7 +29,7 @@ const sendEmail = input => {
     global.connection.query(
       `SELECT * FROM idp WHERE domain=:domain`,
       {
-        domain: req ? util.getIDPDomain(req.headers) : `books.toadreader.com`,
+        domain: req ? util.getIDPDomain({ host: req.headers.host }) : `books.toadreader.com`,
       },
       (err, rows) => {
         if(err) {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -402,7 +402,7 @@ const util = {
     if(req.headers.host.split('.')[2] === 'staging') {
       return util.getFrontEndOrigin({ req, env: 'staging' })
     } else {
-      return `${util.getProtocol({ req })}://${util.getIDPDomain({ host: req.headers.host })}`
+      return `${util.getProtocol({ req })}://${util.getIDPDomain({ host: req.hostname || req.headers.host })}`
     }
   },
 
@@ -491,7 +491,7 @@ const util = {
 
   getFrontEndOrigin: ({ req, env }) => {
 
-    let domain = util.getIDPDomain({ host: req.headers.host, env })
+    let domain = util.getIDPDomain({ host: req.hostname || req.headers.host, env })
 
     if(env ? env === 'dev' : process.env.IS_DEV) {
       domain = `${process.env.DEV_NETWORK_IP || `localhost`}:19006`
@@ -1445,7 +1445,7 @@ const util = {
     const [ idpRow ] = await util.runQuery({
       query: `SELECT id, ${jwtColInIdp} FROM idp WHERE domain=:domain`,
       vars: {
-        domain: util.getIDPDomain({ host: req.headers.host }),
+        domain: util.getIDPDomain({ host: req.hostname || req.headers.host }),
       },
       next,
     })
@@ -1478,7 +1478,7 @@ const util = {
 
     global.connection.query(
       'SELECT language FROM `idp` WHERE domain=?',
-      [util.getIDPDomain({ host: req.headers.host })],
+      [util.getIDPDomain({ host: req.hostname || req.headers.host })],
       (err, rows) => {
         if (err) return next(err)
   

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -402,7 +402,7 @@ const util = {
     if(req.headers.host.split('.')[2] === 'staging') {
       return util.getFrontEndOrigin({ req, env: 'staging' })
     } else {
-      return `${util.getProtocol({ req })}://${util.getIDPDomain(req)}`
+      return `${util.getProtocol({ req })}://${util.getIDPDomain({ host: req.headers.host })}`
     }
   },
 
@@ -1445,7 +1445,7 @@ const util = {
     const [ idpRow ] = await util.runQuery({
       query: `SELECT id, ${jwtColInIdp} FROM idp WHERE domain=:domain`,
       vars: {
-        domain: util.getIDPDomain(req.headers),
+        domain: util.getIDPDomain({ host: req.headers.host }),
       },
       next,
     })
@@ -1478,7 +1478,7 @@ const util = {
 
     global.connection.query(
       'SELECT language FROM `idp` WHERE domain=?',
-      [util.getIDPDomain(req.headers)],
+      [util.getIDPDomain({ host: req.headers.host })],
       (err, rows) => {
         if (err) return next(err)
   


### PR DESCRIPTION
This builds on #40. I've separated it in case you would prefer to not include this.

Hostname is probably set whenever host is, but if it is possible for it to be null it will fall back to host. [Hostname](https://expressjs.com/en/4x/api.html#req.hostname) will use `X-Forwarded-Host` if present, which may be the same as host, but may not be depending on the infrastructure configuration.